### PR TITLE
Support local installs of elm and elm-format

### DIFF
--- a/src/features/elm-format-on-save.ts
+++ b/src/features/elm-format-on-save.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode"
 import * as os from "os"
 import * as child_process from "child_process"
-import { Feature } from "./shared/logic"
+import sharedLogic, { Feature } from "./shared/logic"
 
 export const feature: Feature = ({ context }) => {
   context.subscriptions.push(
@@ -38,7 +38,12 @@ function runElmFormat(document: vscode.TextDocument): Promise<string> {
   const command = `elm-format --stdin --yes`
   const original = document.getText()
   return new Promise((resolve, reject) => {
-    const process_ = child_process.exec(command, async (err, stdout, stderr) => {
+    const process_ = child_process.exec(
+      command,
+      {
+        env: sharedLogic.npxEnv()
+      },
+      async (err, stdout, stderr) => {
       if (err) {
         const ELM_FORMAT_BINARY_NOT_FOUND = 127
         if (err.code === ELM_FORMAT_BINARY_NOT_FOUND || err.message.includes(`'elm-format' is not recognized`)) {

--- a/src/features/error-highlighting.ts
+++ b/src/features/error-highlighting.ts
@@ -128,7 +128,12 @@ const Elm = {
     const command = `(cd ${input.elmJsonFile.projectFolder} && elm make ${deduplicated.join(' ')} --output=/dev/null --report=json)`
     const promise: Promise<ParsedError | undefined> =
       new Promise((resolve) =>
-        child_process.exec(command, async (err, _, stderr) => {
+        child_process.exec(
+          command,
+          {
+            env: sharedLogic.npxEnv()
+          },
+          async (err, _, stderr) => {
           if (err) {
             const ELM_BINARY_NOT_FOUND = 127
             if (err.code === ELM_BINARY_NOT_FOUND || err.message.includes(`'elm' is not recognized`)) {


### PR DESCRIPTION
Fixes #4.

I copied the approach from elm-review (also written by me originally): https://github.com/jfmengels/node-elm-review/blob/888628c2de72e10113b24b75f9753378058490cd/lib/autofix.js#L231-L287

I’ve tested that it works on macOS and Windows.