### PR TITLE
Add go-to-symbol and open-symbol-by-name features

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Visual Studio Code is available for Mac, Windows, and Linux.
 - Offline-friendly package docs
 - Module import autocomplete
 - Convert HTML to Elm
+- Go to symbol
+- Open symbol by name
 
 __More documentation__
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,16 @@ To help you convert HTML snippets to Elm code and help newcomers learn the synta
 
 ---
 
+### __Go to symbol__
+
+__Setting:__ `elmLand.feature.goToSymbol`
+
+You can navigate symbols inside a file. This is helpful for quickly navigating among functions, values and types in a file.
+
+![Go to symbol](./go-to-symbol.gif)
+
+---
+
 ## __Performance Table__
 
 Elm's [editor plugins repo](https://github.com/elm/editor-plugins) recommends doing performance profiling to help others learn how different editors implement features, and also to help try to think of ways to bring down costs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@
   - [Offline package docs](#offline-package-docs)
   - [Module import autocomplete](#module-import-autocomplete)
   - [Convert HTML to Elm](#convert-html-to-elm)
+  - [Go to symbol](#go-to-symbol)
+  - [Open symbol by name](#open-symbol-by-name)
 - 📊 [Performance Table](#performance-table)
 - 💖 [Thank you, Elm community](#thank-you-elm-community)
 - 🛠️ [Want to contribute?](#want-to-contribute)

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,7 +101,7 @@ To help you convert HTML snippets to Elm code and help newcomers learn the synta
 
 __Setting:__ `elmLand.feature.goToSymbol`
 
-You can navigate symbols inside a file. This is helpful for quickly navigating among functions, values and types in a file.
+You can navigate symbols inside a file. This is helpful for quickly navigating among functions, values and types in a file. You can also navigate to any top-level declaration in any file, which is a quick way of getting to the right file.
 
 ![Go to symbol](./go-to-symbol.gif)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,9 +101,19 @@ To help you convert HTML snippets to Elm code and help newcomers learn the synta
 
 __Setting:__ `elmLand.feature.goToSymbol`
 
-You can navigate symbols inside a file. This is helpful for quickly navigating among functions, values and types in a file. You can also navigate to any top-level declaration in any file, which is a quick way of getting to the right file.
+You can navigate symbols inside a file. This is helpful for quickly navigating among functions, values and types in a file. The Outline panel below the file tree in the sidebar also displays all functions, values and types in the file.
 
 ![Go to symbol](./go-to-symbol.gif)
+
+---
+
+### __Open symbol by name__
+
+__Setting:__ `elmLand.feature.openSymbolByName`
+
+You can navigate to any top-level declaration in any file, which is a quick way of getting to the right file.
+
+![Open symbol by name](./open-symbol-by-name.gif)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,12 @@
             "description": "Enable the 'HTML to Elm' feature",
             "type": "boolean",
             "default": true
+          },
+          "elmLand.feature.goToSymbol": {
+            "order": 7,
+            "description": "Enable the 'Go-to-symbol' feature",
+            "type": "boolean",
+            "default": true
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,12 @@
             "description": "Enable the 'Go-to-symbol' feature",
             "type": "boolean",
             "default": true
+          },
+          "elmLand.feature.openSymbolByName": {
+            "order": 8,
+            "description": "Enable the 'Open symbol by name' feature",
+            "type": "boolean",
+            "default": true
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import * as OfflinePackageDocs from "./features/offline-package-docs"
 import * as TypeDrivenAutocomplete from './features/type-driven-autocomplete'
 import * as HtmlToElm from './features/html-to-elm'
 import * as GoToSymbol from "./features/go-to-symbol"
+import * as OpenSymbolByName from "./features/open-symbol-by-name"
 
 export async function activate(context: vscode.ExtensionContext) {
   console.info("ACTIVATE")
@@ -34,6 +35,7 @@ export async function activate(context: vscode.ExtensionContext) {
   TypeDrivenAutocomplete.feature({ globalState, context })
   HtmlToElm.feature({ globalState, context })
   GoToSymbol.feature({ globalState, context })
+  OpenSymbolByName.feature({ globalState, context })
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import * as JumpToDefinition from "./features/jump-to-definition"
 import * as OfflinePackageDocs from "./features/offline-package-docs"
 import * as TypeDrivenAutocomplete from './features/type-driven-autocomplete'
 import * as HtmlToElm from './features/html-to-elm'
+import * as GoToSymbol from "./features/go-to-symbol"
 
 export async function activate(context: vscode.ExtensionContext) {
   console.info("ACTIVATE")
@@ -32,6 +33,7 @@ export async function activate(context: vscode.ExtensionContext) {
   OfflinePackageDocs.feature({ globalState, context })
   TypeDrivenAutocomplete.feature({ globalState, context })
   HtmlToElm.feature({ globalState, context })
+  GoToSymbol.feature({ globalState, context })
 }
 
 export function deactivate() {

--- a/src/features/go-to-symbol.ts
+++ b/src/features/go-to-symbol.ts
@@ -3,6 +3,17 @@ import sharedLogic, { Feature } from './shared/logic'
 import * as ElmToAst from './shared/elm-to-ast'
 import * as ElmSyntax from './shared/elm-to-ast/elm-syntax'
 
+// This finds all top-level declarations (type, type alias, values, functions, ports)
+// with the following caveats:
+// - Odd spacing or inline comments can cause declarations to be missed.
+// - False positives might be found in multiline comments or multiline strings.
+// But it’s a very fast way of computing an important feature!
+// If there are a couple of false positives you can jump to, that’s not the end of the world.
+// For example, if you comment out some code using multiline comments, you’ll still be able
+// to jump to it, which is a bit unexpected but not super weird.
+// Parts come from here: https://github.com/rtfeldman/node-test-runner/blob/eedf853fc9b45afd73a0db72decebdb856a69771/lib/Parser.js#L229-L234
+const topLevelDeclarationRegex = /\n|(?<=^type(?: +alias)? +)\p{Lu}[_\d\p{L}]*|^\p{Ll}[_\d\p{L}]*(?=.*=$)|^(?<=port +)\p{Ll}[_\d\p{L}]*(?= *:)/gmu
+
 type Fallback = {
   fsPath: string
   symbols: vscode.DocumentSymbol[]
@@ -40,6 +51,54 @@ export const feature: Feature = ({ context }) => {
           // syntactically valid again – but I think it’s fine.
           return fallback.symbols
         }
+      }
+    })
+  )
+
+  context.subscriptions.push(
+    vscode.languages.registerWorkspaceSymbolProvider({
+      async provideWorkspaceSymbols(query: string, token: vscode.CancellationToken) {
+        // Allow user to disable this feature
+        const isEnabled: boolean = vscode.workspace.getConfiguration('elmLand').feature.goToSymbol
+        if (!isEnabled) return
+
+        const start = Date.now()
+        const results = []
+        const uris = await vscode.workspace.findFiles('**/*.elm', '**/{node_modules,elm-stuff}/**')
+
+        for (const uri of uris) {
+          const buffer = await vscode.workspace.fs.readFile(uri)
+          const fileContents = Buffer.from(buffer).toString('utf8')
+          let line = 0
+          let lineIndex = 0
+          for (const match of fileContents.matchAll(topLevelDeclarationRegex)) {
+            const { 0: name, index: matchIndex = 0 } = match
+            if (name === '\n') {
+              line++
+              lineIndex = matchIndex
+            } else {
+              const firstLetter = name.slice(0, 1)
+              const character = matchIndex - lineIndex - 1
+              results.push(
+                new vscode.SymbolInformation(
+                  name,
+                  firstLetter.toUpperCase() === firstLetter ? vscode.SymbolKind.Variable : vscode.SymbolKind.Function,
+                  '',
+                  new vscode.Location(
+                    uri,
+                    new vscode.Range(
+                      new vscode.Position(line, character),
+                      new vscode.Position(line, character + name.length)
+                    )
+                  )
+                )
+              )
+            }
+          }
+        }
+
+        console.info('provideWorkspaceSymbol', `${Date.now() - start}ms`)
+        return results
       }
     })
   )

--- a/src/features/go-to-symbol.ts
+++ b/src/features/go-to-symbol.ts
@@ -41,7 +41,7 @@ export const feature: Feature = ({ context }) => {
           return fallback.symbols
         }
       }
-  })
+    })
   )
 }
 

--- a/src/features/go-to-symbol.ts
+++ b/src/features/go-to-symbol.ts
@@ -20,7 +20,7 @@ export const feature: Feature = ({ context }) => {
 
         const start = Date.now()
         const text = doc.getText()
-        const ast = await ElmToAst.run(text)
+        const ast = await ElmToAst.run(text, token)
 
         if (ast) {
           const symbols = ast.declarations.map(declarationToDocumentSymbol)

--- a/src/features/go-to-symbol.ts
+++ b/src/features/go-to-symbol.ts
@@ -68,6 +68,7 @@ export const feature: Feature = ({ context }) => {
 
         for (const uri of uris) {
           const buffer = await vscode.workspace.fs.readFile(uri)
+          if (token.isCancellationRequested) return
           const fileContents = Buffer.from(buffer).toString('utf8')
           let line = 0
           let lineIndex = 0

--- a/src/features/go-to-symbol.ts
+++ b/src/features/go-to-symbol.ts
@@ -3,17 +3,6 @@ import sharedLogic, { Feature } from './shared/logic'
 import * as ElmToAst from './shared/elm-to-ast'
 import * as ElmSyntax from './shared/elm-to-ast/elm-syntax'
 
-// This finds all top-level declarations (type, type alias, values, functions, ports)
-// with the following caveats:
-// - Odd spacing or inline comments can cause declarations to be missed.
-// - False positives might be found in multiline comments or multiline strings.
-// But it’s a very fast way of computing an important feature!
-// If there are a couple of false positives you can jump to, that’s not the end of the world.
-// For example, if you comment out some code using multiline comments, you’ll still be able
-// to jump to it, which is a bit unexpected but not super weird.
-// Parts come from here: https://github.com/rtfeldman/node-test-runner/blob/eedf853fc9b45afd73a0db72decebdb856a69771/lib/Parser.js#L229-L234
-const topLevelDeclarationRegex = /\n|(?<=^type(?: +alias)? +)\p{Lu}[_\d\p{L}]*|^\p{Ll}[_\d\p{L}]*(?=.*=$)|^(?<=port +)\p{Ll}[_\d\p{L}]*(?= *:)/gmu
-
 type Fallback = {
   fsPath: string
   symbols: vscode.DocumentSymbol[]
@@ -56,69 +45,6 @@ export const feature: Feature = ({ context }) => {
       }
     })
   )
-
-  context.subscriptions.push(
-    vscode.languages.registerWorkspaceSymbolProvider({
-      async provideWorkspaceSymbols(query: string, token: vscode.CancellationToken) {
-        // Allow user to disable this feature
-        const isEnabled: boolean = vscode.workspace.getConfiguration('elmLand').feature.goToSymbol
-        if (!isEnabled) return
-
-        const start = Date.now()
-        const symbols: vscode.SymbolInformation[] = []
-        const uris = await vscode.workspace.findFiles('**/*.elm', '**/{node_modules,elm-stuff}/**')
-
-        for (const uri of uris) {
-          const buffer = await vscode.workspace.fs.readFile(uri)
-          if (token.isCancellationRequested) return
-          const fileContents = Buffer.from(buffer).toString('utf8')
-          let line = 0
-          let lineIndex = 0
-          for (const match of fileContents.matchAll(topLevelDeclarationRegex)) {
-            const { 0: name, index: matchIndex = 0 } = match
-            if (name === '\n') {
-              line++
-              lineIndex = matchIndex
-            } else if (nameMatchesQuery(name, query)) {
-              const firstLetter = name.slice(0, 1)
-              const character = matchIndex - lineIndex - 1
-              symbols.push(
-                new vscode.SymbolInformation(
-                  name,
-                  firstLetter.toUpperCase() === firstLetter ? vscode.SymbolKind.Variable : vscode.SymbolKind.Function,
-                  '',
-                  new vscode.Location(
-                    uri,
-                    new vscode.Range(
-                      new vscode.Position(line, character),
-                      new vscode.Position(line, character + name.length)
-                    )
-                  )
-                )
-              )
-            }
-          }
-        }
-
-        console.info('provideWorkspaceSymbol', `${symbols.length} results in ${Date.now() - start}ms`)
-        return symbols
-      }
-    })
-  )
-}
-
-// Checks that the characters of `query` appear in their order in a candidate symbol,
-// as documented here: https://code.visualstudio.com/api/references/vscode-api#WorkspaceSymbolProvider
-const nameMatchesQuery = (name: string, query: string): boolean => {
-  const nameChars = Array.from(name)
-  let nameIndex = 0
-  outer: for (const char of query) {
-    for (; nameIndex < nameChars.length; nameIndex++) {
-      if (nameChars[nameIndex] === char) continue outer
-    }
-    return false
-  }
-  return true
 }
 
 const declarationToDocumentSymbol = (declaration: ElmSyntax.Node<ElmSyntax.Declaration>): vscode.DocumentSymbol => {

--- a/src/features/go-to-symbol.ts
+++ b/src/features/go-to-symbol.ts
@@ -32,11 +32,11 @@ export const feature: Feature = ({ context }) => {
           return symbols
         } else if (fallback !== undefined && doc.uri.fsPath === fallback.fsPath) {
           // When you start editing code, it won’t have correct syntax straight away,
-          // but VSCode will re-run this. If you have the Outline panel in the sidebar,
-          // it’s quite distracting if we return an empty list here – the list will flash
+          // but VSCode will re-run this. If you have the Outline panel open in the sidebar,
+          // it’s quite distracting if we return an empty list here – it will flash
           // between “no symbols” and all the symbols. So returning the symbols from last
-          // time we got any improves the UX a little. Note: If you remove all text in the,
-          // the Outline view will show old stuff that isn’t available until the file becomes
+          // time we got any improves the UX a little. Note: If you remove all text in the file,
+          // the Outline view shows old stuff that isn’t available – until the file becomes
           // syntactically valid again – but I think it’s fine.
           return fallback.symbols
         }

--- a/src/features/go-to-symbol.ts
+++ b/src/features/go-to-symbol.ts
@@ -242,6 +242,7 @@ const typeAliasSymbolKind = (typeAnnotation: ElmSyntax.TypeAnnotation): vscode.S
     case 'typed': return vscode.SymbolKind.Variable
     case 'unit': return vscode.SymbolKind.Variable
     case 'tupled': return vscode.SymbolKind.Variable
+    // `vscode.SymbolKind.Object` gives a nice icon looking like this: {}
     case 'record': return vscode.SymbolKind.Object
     case 'genericRecord': return vscode.SymbolKind.Object
   }

--- a/src/features/go-to-symbol.ts
+++ b/src/features/go-to-symbol.ts
@@ -63,13 +63,7 @@ const declarationToDocumentSymbol = (declaration: ElmSyntax.Node<ElmSyntax.Decla
     symbolKind: vscode.SymbolKind,
     children: vscode.DocumentSymbol[]
   ) => {
-    const documentSymbol = new vscode.DocumentSymbol(
-      name.value,
-      '',
-      symbolKind,
-      sharedLogic.fromElmRange(declaration.range),
-      sharedLogic.fromElmRange(name.range)
-    )
+    const documentSymbol = symbol(name, symbolKind)
     documentSymbol.children = children
     return documentSymbol
   }

--- a/src/features/go-to-symbol.ts
+++ b/src/features/go-to-symbol.ts
@@ -1,0 +1,87 @@
+import * as vscode from 'vscode'
+import sharedLogic, { Feature } from './shared/logic'
+import * as ElmToAst from './shared/elm-to-ast'
+import * as ElmSyntax from './shared/elm-to-ast/elm-syntax'
+import { GlobalState } from './shared/autodetect-elm-json'
+import { ElmJsonFile } from './shared/elm-json-file'
+
+export const feature: Feature = ({ globalState, context }) => {
+  context.subscriptions.push(
+    vscode.languages.registerDocumentSymbolProvider('elm', provider(globalState))
+  )
+}
+
+// TODO: Inline and remove globalState?
+const provider = (globalState: GlobalState) => {
+  return {
+    // TODO: vscode.ProviderResult<vscode.DocumentSymbol[] | vscode.SymbolInformation[]>
+    async provideDocumentSymbols(doc: vscode.TextDocument, token: vscode.CancellationToken) {
+      // Allow user to disable this feature
+      const isEnabled: boolean = vscode.workspace.getConfiguration('elmLand').feature.goToSymbol
+      if (!isEnabled) return
+
+      const start = Date.now()
+      const text = doc.getText()
+      const ast = await ElmToAst.run(text)
+
+      if (ast) {
+        const symbols = ast.declarations.map(declaration => {
+          const a = new vscode.DocumentSymbol(
+            /**
+             * The name of this symbol.
+             */
+            "Namn",
+
+            /**
+             * More detail for this symbol, e.g. the signature of a function.
+             */
+            // TODO: Provide the signature?
+            "(detail)",
+
+            /**
+             * The kind of this symbol.
+             */
+            // TODO: Depends on what kind of declaration.
+            vscode.SymbolKind.Function,
+
+            /**
+             * Tags for this symbol.
+             */
+            // TODO: Can look for @deprecated and mark as deprecated?
+            // tags?: readonly SymbolTag[],
+
+            /**
+             * The range enclosing this symbol not including leading/trailing whitespace but everything else, e.g. comments and code.
+             */
+            sharedLogic.fromElmRange(declaration.range),
+
+            /**
+             * The range that should be selected and reveal when this symbol is being picked, e.g. the name of a function.
+             * Must be contained by the {@linkcode DocumentSymbol.range range}.
+             */
+            // TODO: Closer range
+            sharedLogic.fromElmRange(declaration.range),
+
+            /**
+             * Children of this symbol, e.g. properties of a class.
+             */
+            // TODO: let bindings?
+            // and how to add them? mutate it afterwards?
+            // yep
+            // [],
+
+          )
+          a.children = [
+            new vscode.DocumentSymbol("child", "", vscode.SymbolKind.Constant, sharedLogic.fromElmRange(declaration.range), sharedLogic.fromElmRange(declaration.range))
+          ]
+          // Seems to just be a less advanced variant?
+          // const b: vscode.SymbolInformation = x
+          return a
+        })
+
+        console.info('provideDocumentSymbol', `${Date.now() - start}ms`)
+        return symbols
+      }
+    }
+  }
+}

--- a/src/features/offline-package-docs.ts
+++ b/src/features/offline-package-docs.ts
@@ -22,7 +22,7 @@ export const feature: Feature = ({ globalState, context }) => {
 
       let start = Date.now()
       let text = document.getText()
-      let ast = await ElmToAst.run(text)
+      let ast = await ElmToAst.run(text, token)
       let uri = vscode.Uri.parse("command:elmLand.browsePackageDocs")
       let elmJsonFile = SharedLogic.findElmJsonFor(globalState, document.uri)
 

--- a/src/features/open-symbol-by-name.ts
+++ b/src/features/open-symbol-by-name.ts
@@ -1,0 +1,78 @@
+import * as vscode from 'vscode'
+import { Feature } from './shared/logic'
+
+// This finds all top-level declarations (type, type alias, values, functions, ports)
+// with the following caveats:
+// - Odd spacing or inline comments can cause declarations to be missed.
+// - False positives might be found in multiline comments or multiline strings.
+// But it’s a very fast way of computing an important feature!
+// If there are a couple of false positives you can jump to, that’s not the end of the world.
+// For example, if you comment out some code using multiline comments, you’ll still be able
+// to jump to it, which is a bit unexpected but not super weird.
+// Parts come from here: https://github.com/rtfeldman/node-test-runner/blob/eedf853fc9b45afd73a0db72decebdb856a69771/lib/Parser.js#L229-L234
+const topLevelDeclarationRegex = /\n|(?<=^type(?: +alias)? +)\p{Lu}[_\d\p{L}]*|^\p{Ll}[_\d\p{L}]*(?=.*=$)|^(?<=port +)\p{Ll}[_\d\p{L}]*(?= *:)/gmu
+
+export const feature: Feature = ({ context }) => {
+  context.subscriptions.push(
+    vscode.languages.registerWorkspaceSymbolProvider({
+      async provideWorkspaceSymbols(query: string, token: vscode.CancellationToken) {
+        // Allow user to disable this feature
+        const isEnabled: boolean = vscode.workspace.getConfiguration('elmLand').feature.openSymbolByName
+        if (!isEnabled) return
+
+        const start = Date.now()
+        const symbols: vscode.SymbolInformation[] = []
+        const uris = await vscode.workspace.findFiles('**/*.elm', '**/{node_modules,elm-stuff}/**')
+
+        for (const uri of uris) {
+          const buffer = await vscode.workspace.fs.readFile(uri)
+          if (token.isCancellationRequested) return
+          const fileContents = Buffer.from(buffer).toString('utf8')
+          let line = 0
+          let lineIndex = 0
+          for (const match of fileContents.matchAll(topLevelDeclarationRegex)) {
+            const { 0: name, index: matchIndex = 0 } = match
+            if (name === '\n') {
+              line++
+              lineIndex = matchIndex
+            } else if (nameMatchesQuery(name, query)) {
+              const firstLetter = name.slice(0, 1)
+              const character = matchIndex - lineIndex - 1
+              symbols.push(
+                new vscode.SymbolInformation(
+                  name,
+                  firstLetter.toUpperCase() === firstLetter ? vscode.SymbolKind.Variable : vscode.SymbolKind.Function,
+                  '',
+                  new vscode.Location(
+                    uri,
+                    new vscode.Range(
+                      new vscode.Position(line, character),
+                      new vscode.Position(line, character + name.length)
+                    )
+                  )
+                )
+              )
+            }
+          }
+        }
+
+        console.info('provideWorkspaceSymbol', `${symbols.length} results in ${Date.now() - start}ms`)
+        return symbols
+      }
+    })
+  )
+}
+
+// Checks that the characters of `query` appear in their order in a candidate symbol,
+// as documented here: https://code.visualstudio.com/api/references/vscode-api#WorkspaceSymbolProvider
+const nameMatchesQuery = (name: string, query: string): boolean => {
+  const nameChars = Array.from(name)
+  let nameIndex = 0
+  outer: for (const char of query) {
+    for (; nameIndex < nameChars.length; nameIndex++) {
+      if (nameChars[nameIndex] === char) continue outer
+    }
+    return false
+  }
+  return true
+}

--- a/src/features/open-symbol-by-name.ts
+++ b/src/features/open-symbol-by-name.ts
@@ -65,10 +65,11 @@ export const feature: Feature = ({ context }) => {
 
 // Checks that the characters of `query` appear in their order in a candidate symbol,
 // as documented here: https://code.visualstudio.com/api/references/vscode-api#WorkspaceSymbolProvider
+// In TypeScript, this is case insensitive, so we do that too.
 const nameMatchesQuery = (name: string, query: string): boolean => {
-  const nameChars = Array.from(name)
+  const nameChars = Array.from(name.toLowerCase())
   let nameIndex = 0
-  outer: for (const char of query) {
+  outer: for (const char of query.toLowerCase()) {
     for (; nameIndex < nameChars.length; nameIndex++) {
       if (nameChars[nameIndex] === char) continue outer
     }

--- a/src/features/shared/elm-to-ast/README.md
+++ b/src/features/shared/elm-to-ast/README.md
@@ -1,8 +1,6 @@
 # Elm to AST
 > A script that turns raw Elm source code into a structured JSON value
 
-This script is intentionally commited to source control so there's no extra build step needed to run this plugin.
-
 ## Building from scratch
 
 1. Install these NPM terminal commands

--- a/src/features/shared/elm-to-ast/index.ts
+++ b/src/features/shared/elm-to-ast/index.ts
@@ -4,34 +4,56 @@ import * as WorkerThreads from 'worker_threads'
 import * as ElmSyntax from './elm-syntax'
 
 type WorkerState =
-  | { tag: 'NotRunning' }
-  | { tag: 'Idle', worker: WorkerThreads.Worker }
-  | { tag: 'Busy', worker: WorkerThreads.Worker, resolve: (result: ElmSyntax.Ast | undefined) => void, queue: QueueItem[] }
+  | { tag: 'Idle' }
+  | { tag: 'Busy', resolve: (result: ElmSyntax.Ast | undefined) => void, queue: QueueItem[] }
 
 type QueueItem = {
   rawElmSource: string
   resolve: (result: ElmSyntax.Ast | undefined) => void,
 }
 
-let workerState: WorkerState = { tag: 'NotRunning' }
+let worker: WorkerThreads.Worker
+let workerState: WorkerState = { tag: 'Idle' }
+
+const initWorker = () => {
+  worker = new WorkerThreads.Worker(path.join(__dirname, './worker.js'))
+
+  const finish = (result: ElmSyntax.Ast | undefined) => {
+    if (workerState.tag === 'Busy') {
+      workerState.resolve(result)
+      const next = workerState.queue.shift()
+      if (next === undefined) {
+        workerState = { tag: 'Idle' }
+      } else {
+        workerState.resolve = next.resolve
+        worker.postMessage(next.rawElmSource)
+      }
+    }
+  }
+
+  worker.on('exit', () => {
+    // Most likely, we terminated a busy worker.
+    initWorker()
+    finish(undefined)
+  })
+
+  worker.on('message', finish)
+}
+
+initWorker()
 
 export const run = async (rawElmSource: string, token: vscode.CancellationToken): Promise<ElmSyntax.Ast | undefined> => {
   return new Promise((resolve) => {
     token.onCancellationRequested(() => {
       if (workerState.tag === 'Busy' && workerState.resolve === resolve) {
-        workerState.worker.terminate()
+        worker.terminate()
       }
     })
 
     switch (workerState.tag) {
-      case 'NotRunning':
-        workerState = { tag: 'Busy', worker: initWorker(), resolve, queue: [] }
-        workerState.worker.postMessage(rawElmSource)
-        break
-
       case 'Idle':
-        workerState = { tag: 'Busy', worker: workerState.worker, resolve, queue: [] }
-        workerState.worker.postMessage(rawElmSource)
+        workerState = { tag: 'Busy', resolve, queue: [] }
+        worker.postMessage(rawElmSource)
         break
 
       case 'Busy':
@@ -39,65 +61,4 @@ export const run = async (rawElmSource: string, token: vscode.CancellationToken)
         break
     }
   })
-}
-
-const initWorker = (): WorkerThreads.Worker => {
-  const worker = new WorkerThreads.Worker(path.join(__dirname, './worker.js'))
-
-  worker.on('error', (error) => {
-    console.error(`ElmToAst`, `Worker error:`, error)
-    worker.terminate()
-    if (workerState.tag === 'Busy') {
-      workerState.resolve(undefined)
-      for (const queueItem of workerState.queue) {
-        queueItem.resolve(undefined)
-      }
-    }
-    workerState = { tag: 'NotRunning' }
-  })
-
-  const finish = (result: ElmSyntax.Ast | undefined) => {
-    if (workerState.tag === 'Busy') {
-      workerState.resolve(result)
-      const next = workerState.queue.shift()
-      if (next === undefined) {
-        workerState = { tag: 'Idle', worker: workerState.worker }
-      } else {
-        workerState.resolve = next.resolve
-        workerState.worker.postMessage(next.rawElmSource)
-      }
-    }
-  }
-
-  worker.on('exit', () => {
-    // Most likely, we terminated a busy worker, so there is no error to report.
-    if (workerState.tag === 'Busy') {
-      workerState.resolve(undefined)
-      const next = workerState.queue.shift()
-      if (next === undefined) {
-        workerState = { tag: 'Idle', worker: initWorker() }
-      } else {
-        workerState.resolve = next.resolve
-        workerState.worker = initWorker()
-        workerState.worker.postMessage(next.rawElmSource)
-      }
-    } else {
-      workerState = { tag: 'NotRunning' }
-    }
-  })
-
-  worker.on('message', (result: ElmSyntax.Ast | undefined) => {
-    if (workerState.tag === 'Busy') {
-      workerState.resolve(result)
-      const next = workerState.queue.shift()
-      if (next === undefined) {
-        workerState = { tag: 'Idle', worker: workerState.worker }
-      } else {
-        workerState.resolve = next.resolve
-        workerState.worker.postMessage(next.rawElmSource)
-      }
-    }
-  })
-
-  return worker
 }

--- a/src/features/shared/elm-to-ast/index.ts
+++ b/src/features/shared/elm-to-ast/index.ts
@@ -6,69 +6,97 @@ import * as ElmSyntax from './elm-syntax'
 type WorkerState =
   | { tag: 'NotRunning' }
   | { tag: 'Idle', worker: WorkerThreads.Worker }
-  | { tag: 'Busy', worker: WorkerThreads.Worker }
+  | { tag: 'Busy', worker: WorkerThreads.Worker, resolve: (result: ElmSyntax.Ast | undefined) => void, queue: QueueItem[] }
+
+type QueueItem = {
+  rawElmSource: string
+  resolve: (result: ElmSyntax.Ast | undefined) => void,
+}
 
 let workerState: WorkerState = { tag: 'NotRunning' }
 
 export const run = async (rawElmSource: string, token: vscode.CancellationToken): Promise<ElmSyntax.Ast | undefined> => {
   return new Promise((resolve) => {
-    const worker = getWorker(resolve)
-    const newWorkerState: WorkerState = { tag: 'Busy', worker }
     token.onCancellationRequested(() => {
-      if (workerState === newWorkerState) {
-        // Maybe it’s better to never terminate? Just let the thread chug along?
-        // or queue things? only terminate if cancellation requested?
-        console.info('CANCEL!!!')
-        worker.terminate()
-      } else {
-        console.info('DONT CANCEL')
+      if (workerState.tag === 'Busy' && workerState.resolve === resolve) {
+        workerState.worker.terminate()
       }
     })
-    workerState = newWorkerState
-    worker.postMessage(rawElmSource)
+
+    switch (workerState.tag) {
+      case 'NotRunning':
+        workerState = { tag: 'Busy', worker: initWorker(), resolve, queue: [] }
+        workerState.worker.postMessage(rawElmSource)
+        break
+
+      case 'Idle':
+        workerState = { tag: 'Busy', worker: workerState.worker, resolve, queue: [] }
+        workerState.worker.postMessage(rawElmSource)
+        break
+
+      case 'Busy':
+        workerState.queue.push({ rawElmSource, resolve })
+        break
+    }
   })
 }
 
-const getWorker = (resolve: (result: ElmSyntax.Ast | undefined) => void): WorkerThreads.Worker => {
-  console.info('STATE', workerState.tag)
-  switch (workerState.tag) {
-    case 'NotRunning':
-      return initWorker(resolve)
-
-    case 'Idle':
-      return workerState.worker
-
-    case 'Busy':
-      workerState.worker.terminate()
-      return initWorker(resolve)
-  }
-}
-
-const initWorker = (resolve: (result: ElmSyntax.Ast | undefined) => void): WorkerThreads.Worker => {
+const initWorker = (): WorkerThreads.Worker => {
   const worker = new WorkerThreads.Worker(path.join(__dirname, './worker.js'))
 
   worker.on('error', (error) => {
     console.error(`ElmToAst`, `Worker error:`, error)
     worker.terminate()
+    if (workerState.tag === 'Busy') {
+      workerState.resolve(undefined)
+      for (const queueItem of workerState.queue) {
+        queueItem.resolve(undefined)
+      }
+    }
     workerState = { tag: 'NotRunning' }
-    resolve(undefined)
   })
 
-  worker.on('messageerror', (error) => {
-    console.error(`ElmToAst`, `Worker messageerror:`, error)
-    worker.terminate()
-    workerState = { tag: 'NotRunning' }
-    resolve(undefined)
-  })
+  const finish = (result: ElmSyntax.Ast | undefined) => {
+    if (workerState.tag === 'Busy') {
+      workerState.resolve(result)
+      const next = workerState.queue.shift()
+      if (next === undefined) {
+        workerState = { tag: 'Idle', worker: workerState.worker }
+      } else {
+        workerState.resolve = next.resolve
+        workerState.worker.postMessage(next.rawElmSource)
+      }
+    }
+  }
 
   worker.on('exit', () => {
     // Most likely, we terminated a busy worker, so there is no error to report.
-    resolve(undefined)
+    if (workerState.tag === 'Busy') {
+      workerState.resolve(undefined)
+      const next = workerState.queue.shift()
+      if (next === undefined) {
+        workerState = { tag: 'Idle', worker: initWorker() }
+      } else {
+        workerState.resolve = next.resolve
+        workerState.worker = initWorker()
+        workerState.worker.postMessage(next.rawElmSource)
+      }
+    } else {
+      workerState = { tag: 'NotRunning' }
+    }
   })
 
-  worker.on('message', (result) => {
-    workerState = { tag: 'Idle', worker }
-    resolve(result)
+  worker.on('message', (result: ElmSyntax.Ast | undefined) => {
+    if (workerState.tag === 'Busy') {
+      workerState.resolve(result)
+      const next = workerState.queue.shift()
+      if (next === undefined) {
+        workerState = { tag: 'Idle', worker: workerState.worker }
+      } else {
+        workerState.resolve = next.resolve
+        workerState.worker.postMessage(next.rawElmSource)
+      }
+    }
   })
 
   return worker

--- a/src/features/shared/elm-to-ast/worker.ts
+++ b/src/features/shared/elm-to-ast/worker.ts
@@ -1,0 +1,34 @@
+import * as WorkerThreads from 'worker_threads'
+import * as ElmSyntax from './elm-syntax'
+const Elm: CompiledElmFile = require('./worker.min.js').Elm
+
+type CompiledElmFile = {
+  Worker: {
+    init: () => ElmApp
+  }
+}
+
+type ElmApp = {
+  ports: {
+    input: { send: (rawElmSource: string) => void }
+    onSuccess: { subscribe: (fn: (ast: ElmSyntax.Ast) => void) => void }
+    onFailure: { subscribe: (fn: (reason: string) => void) => void }
+  }
+}
+
+const {parentPort} = WorkerThreads
+if (parentPort === null) {
+  throw new Error('parentPort is null')
+}
+
+const app = Elm.Worker.init()
+app.ports.onSuccess.subscribe((ast) => {
+  parentPort.postMessage(ast)
+})
+app.ports.onFailure.subscribe((reason) => {
+  parentPort.postMessage(undefined)
+})
+
+parentPort.on('message', (rawElmSource: string) => {
+  app.ports.input.send(rawElmSource)
+})

--- a/src/features/type-driven-autocomplete.ts
+++ b/src/features/type-driven-autocomplete.ts
@@ -83,7 +83,7 @@ export const feature: Feature = ({ globalState, context }) => {
             let elmJsonFile = SharedLogic.findElmJsonFor(globalState, document.uri)
 
             if (elmJsonFile) {
-              let moduleDoc = await findLocalElmModuleDoc({ elmJsonFile, moduleName })
+              let moduleDoc = await findLocalElmModuleDoc({ elmJsonFile, moduleName, token })
               if (moduleDoc) {
                 console.info(`autocomplete`, `${Date.now() - start}ms`)
                 return toCompletionItems(moduleDoc, allModuleNames)
@@ -105,7 +105,7 @@ export const feature: Feature = ({ globalState, context }) => {
 // SCANNING LOCAL PROJECT FILES
 
 const findLocalElmModuleDoc =
-  async ({ elmJsonFile, moduleName }: { elmJsonFile: ElmJsonFile, moduleName: string }): Promise<ModuleDoc | undefined> => {
+  async ({ elmJsonFile, moduleName, token }: { elmJsonFile: ElmJsonFile, moduleName: string, token: vscode.CancellationToken }): Promise<ModuleDoc | undefined> => {
 
     let matchingFilepaths = await SharedLogic.keepFilesThatExist(elmJsonFile.sourceDirectories
       .map(folder => path.join(folder, ...moduleName.split('.')) + '.elm'))
@@ -116,7 +116,7 @@ const findLocalElmModuleDoc =
       let uri = vscode.Uri.file(matchingFilepath)
       let document = await vscode.workspace.openTextDocument(uri)
       if (document) {
-        let ast = await ElmToAst.run(document.getText())
+        let ast = await ElmToAst.run(document.getText(), token)
         if (ast) {
           return toModuleDoc(ast)
         }


### PR DESCRIPTION
Status: This seems to work well for me. I just need Ryan’s help with the docs stuff (we talked about it IRL a while ago).

This implements [Go to Symbol](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-symbol) and the [Outline view](https://code.visualstudio.com/docs/getstarted/userinterface#_outline-view) (they go together), as well as [Open symbol by name](https://code.visualstudio.com/docs/editor/editingevolved#_open-symbol-by-name) (which is a bit hacky, but I think it provides a lot of value even if it’s not 100 % pedantically correct). That’s what VSCode calls those features (see the links), but personally I think it’s not super clear what is what. Open to name changes if you want!

At first, on a large file it was too slow (when typing, the UI locked up and the characters appeared too late). It turned out 99.9 % of the time was spent parsing. I solved this by parsing in a [Worker Thread](https://nodejs.org/api/worker_threads.html). So now it never blocks the main thread. For small files, the outline feels instant (like 15 ms), and for big files I notice a ~0.5 second delay for it sometimes.

Note that the worker stuff is a bit tricky, so some extra testing might be good – this affects all features that parses using elm-syntax.