### PR TITLE
Use Map instead of Record to avoid the toString problem

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ export async function activate(context: vscode.ExtensionContext) {
   let globalState: GlobalState = {
     isFirstTimeRunningPlugin: true,
     elmJsonFiles: [],
-    cachedDocs: {},
+    cachedDocs: new Map(),
     jumpToDocDetails: undefined
   }
   context.subscriptions.push({

--- a/src/features/jump-to-definition.ts
+++ b/src/features/jump-to-definition.ts
@@ -139,7 +139,7 @@ const provider = (globalState: GlobalState) => {
     } = ElmSyntax.getInitialPreludeMappings()
 
     const findImportedModuleNamesThatMightHaveExposedThisValue = (moduleName: string): string[] => {
-      let explicitMatches = explicitExposingValuesForImports[moduleName] || []
+      let explicitMatches = explicitExposingValuesForImports.get(moduleName) ?? []
       return explicitMatches.concat(hasUnknownImportsFromExposingAll)
     }
 
@@ -315,7 +315,7 @@ const provider = (globalState: GlobalState) => {
           // would return "Html.Attributes"
           let parentModuleName = parentModules.join('.')
 
-          let aliases = aliasMappingToModuleNames[parentModuleName] || []
+          let aliases = aliasMappingToModuleNames.get(parentModuleName) ?? []
           let moduleNamesToCheck = [parentModuleName].concat(aliases)
 
           // Check local project files
@@ -859,8 +859,12 @@ const provider = (globalState: GlobalState) => {
       if (import_.value.moduleAlias) {
         let alias = import_.value.moduleAlias.value[0]
         if (alias !== undefined) {
-          aliasMappingToModuleNames[alias] = aliasMappingToModuleNames[alias] || [] as string[]
-          (aliasMappingToModuleNames[alias] as any).push(moduleName)
+          const previous = aliasMappingToModuleNames.get(alias)
+          if (previous === undefined) {
+            aliasMappingToModuleNames.set(alias, [moduleName])
+          } else {
+            previous.push(moduleName)
+          }
         }
       }
 
@@ -877,8 +881,12 @@ const provider = (globalState: GlobalState) => {
               .map(node => ElmSyntax.toTopLevelExposeName(node.value))
 
           for (let exportedName of namesOfExportedThings) {
-            explicitExposingValuesForImports[exportedName] = explicitExposingValuesForImports[exportedName] || [] as string[]
-            (explicitExposingValuesForImports[exportedName] as string[]).push(moduleName)
+            const previous = explicitExposingValuesForImports.get(exportedName)
+            if (previous === undefined) {
+              explicitExposingValuesForImports.set(exportedName, [moduleName])
+            } else {
+              previous.push(moduleName)
+            }
           }
 
           if (isExposingAnyCustomVariants) {

--- a/src/features/jump-to-definition.ts
+++ b/src/features/jump-to-definition.ts
@@ -45,15 +45,13 @@ const provider = (globalState: GlobalState) => {
   }
 
   type HandleJumpToLinksForImportsInput = {
-    document: vscode.TextDocument
     position: vscode.Position
     ast: ElmSyntax.Ast
     elmJsonFile: ElmJsonFile
-    packages: Packages
   }
 
   const handleJumpToLinksForImports =
-    async ({ document, position, ast, elmJsonFile, packages }: HandleJumpToLinksForImportsInput)
+    async ({ position, ast, elmJsonFile }: HandleJumpToLinksForImportsInput)
       : Promise<vscode.Location | null> => {
 
       for (let import_ of ast.imports) {
@@ -128,10 +126,9 @@ const provider = (globalState: GlobalState) => {
     ast: ElmSyntax.Ast,
     doc: vscode.TextDocument
     elmJsonFile: ElmJsonFile
-    packages: Packages
   }
 
-  const handleJumpToLinksForDeclarations = async ({ position, ast, doc, elmJsonFile, packages }: HandleJumpToLinksForDeclarationsInput): Promise<vscode.Location | null> => {
+  const handleJumpToLinksForDeclarations = async ({ position, ast, doc, elmJsonFile }: HandleJumpToLinksForDeclarationsInput): Promise<vscode.Location | null> => {
     let {
       aliasMappingToModuleNames,
       explicitExposingValuesForImports,
@@ -989,15 +986,14 @@ const provider = (globalState: GlobalState) => {
           }
 
           // Handle module imports
-          let packages = await sharedLogic.getMappingOfModuleNameToDocJsonFilepath(globalState, elmJsonFile)
-          matchingLocation = await handleJumpToLinksForImports({ document: doc, position, ast, elmJsonFile, packages })
+          matchingLocation = await handleJumpToLinksForImports({ position, ast, elmJsonFile })
           if (matchingLocation) {
             console.info('provideDefinition', `${Date.now() - start}ms`)
             return matchingLocation
           }
 
           // Handle module declarations
-          matchingLocation = await handleJumpToLinksForDeclarations({ position, ast, doc, elmJsonFile, packages })
+          matchingLocation = await handleJumpToLinksForDeclarations({ position, ast, doc, elmJsonFile })
           if (matchingLocation) {
             console.info('provideDefinition', `${Date.now() - start}ms`)
             return matchingLocation

--- a/src/features/offline-package-docs.ts
+++ b/src/features/offline-package-docs.ts
@@ -37,8 +37,8 @@ export const feature: Feature = ({ globalState, context }) => {
           let moduleNameNode = importNode.value.moduleName
           let range = SharedLogic.fromElmRange(moduleNameNode.range)
           let moduleName = moduleNameNode.value.join(".")
-          let docsJsonFsPath = packages[moduleName]
-          if (docsJsonFsPath) {
+          let docsJsonFsPath = packages.get(moduleName)
+          if (docsJsonFsPath !== undefined) {
             details.push({
               range,
               docsJsonFsPath,
@@ -258,8 +258,8 @@ export const feature: Feature = ({ globalState, context }) => {
                     )
 
                 for (let moduleName of moduleNames) {
-                  let docsJsonFsPath = packages[moduleName]
-                  if (docsJsonFsPath) {
+                  let docsJsonFsPath = packages.get(moduleName)
+                  if (docsJsonFsPath !== undefined) {
                     let typeOrValueName = await SharedLogic.doesModuleExposesValue(
                       globalState,
                       foo,
@@ -343,8 +343,8 @@ export const feature: Feature = ({ globalState, context }) => {
                     )
 
                 for (let moduleName of moduleNames) {
-                  let docsJsonFsPath = packages[moduleName]
-                  if (docsJsonFsPath) {
+                  let docsJsonFsPath = packages.get(moduleName)
+                  if (docsJsonFsPath !== undefined) {
                     let typeOrValueName = await SharedLogic.doesModuleExposesValue(
                       globalState,
                       foo,

--- a/src/features/shared/autodetect-elm-json.ts
+++ b/src/features/shared/autodetect-elm-json.ts
@@ -7,7 +7,7 @@ import sharedLogic from './logic'
 export type GlobalState = {
   isFirstTimeRunningPlugin: boolean
   elmJsonFiles: ElmJsonFile[]
-  cachedDocs: Record<string, ModuleDoc[]>
+  cachedDocs: Map<string, ModuleDoc[]>
   jumpToDocDetails: JumpToDocDetails[] | undefined
 }
 
@@ -51,7 +51,7 @@ export const run = async (globalState: GlobalState) => {
   let elmJsonFileUris = await vscode.workspace.findFiles('**/elm.json', '**/node_modules/**', 10)
   let possibleElmJsonFiles = await Promise.all(toElmJsonFiles({ elmJsonFileUris, settings }))
   globalState.elmJsonFiles = possibleElmJsonFiles.filter(sharedLogic.isDefined)
-  globalState.cachedDocs = {}
+  globalState.cachedDocs = new Map()
   console.info(`autodetectElmJson`, `${Date.now() - start}ms`)
 }
 

--- a/src/features/shared/elm-json-file.ts
+++ b/src/features/shared/elm-json-file.ts
@@ -53,18 +53,18 @@ export type BinOp = {
 
 
 export const getDocumentationForElmPackage = async (globalState: GlobalState, fsPath: string): Promise<ModuleDoc[]> => {
-  let cachedDocsForThisFsPath = globalState.cachedDocs[fsPath]
+  let cachedDocsForThisFsPath = globalState.cachedDocs.get(fsPath)
 
-  if (cachedDocsForThisFsPath) {
+  if (cachedDocsForThisFsPath !== undefined) {
     return cachedDocsForThisFsPath
   } else {
     try {
       let buffer = await vscode.workspace.fs.readFile(vscode.Uri.file(fsPath))
       let contents = Buffer.from(buffer).toString('utf8')
       let json = JSON.parse(contents)
-      globalState.cachedDocs[fsPath] = json
+      globalState.cachedDocs.set(fsPath, json)
       return json
-    } catch (_) {
+    } catch {
       return []
     }
   }

--- a/src/features/shared/logic.ts
+++ b/src/features/shared/logic.ts
@@ -23,20 +23,20 @@ let findElmJsonFor = (globalState: AutodetectElmJson.GlobalState, uri: vscode.Ur
   }
 }
 
-const getMappingOfModuleNameToDocJsonFilepath = async (globalState: AutodetectElmJson.GlobalState, elmJsonFile: ElmJsonFile): Promise<Record<string, string>> => {
-  let packages: { [key: string]: string } = {}
+const getMappingOfModuleNameToDocJsonFilepath = async (globalState: AutodetectElmJson.GlobalState, elmJsonFile: ElmJsonFile): Promise<Map<string, string>> => {
+  const packages = new Map<string, string>()
   const dependencies = elmJsonFile.dependencies
-  for (let dep of dependencies) {
-    let docs = await getDocumentationForElmPackage(globalState, dep.fsPath)
-    for (let doc of docs) {
-      packages[doc.name] = dep.fsPath
+  for (const dep of dependencies) {
+    const docs = await getDocumentationForElmPackage(globalState, dep.fsPath)
+    for (const doc of docs) {
+      packages.set(doc.name, dep.fsPath)
     }
   }
 
   return packages
 }
 
-const findFirstOccurenceOfWordInFile = (word: string, rawJsonString: string): [number, number, number, number] | undefined => {
+const findFirstOccurrenceOfWordInFile = (word: string, rawJsonString: string): [number, number, number, number] | undefined => {
   if (word && rawJsonString) {
     const regex = new RegExp(word, 'm')
     const match = rawJsonString.match(regex)
@@ -104,7 +104,7 @@ export default {
   findElmJsonFor,
   fromElmRange,
   getMappingOfModuleNameToDocJsonFilepath,
-  findFirstOccurenceOfWordInFile,
+  findFirstOccurenceOfWordInFile: findFirstOccurrenceOfWordInFile,
   isDefined,
   doesModuleExposesValue,
   keepFilesThatExist

--- a/src/features/type-driven-autocomplete.ts
+++ b/src/features/type-driven-autocomplete.ts
@@ -25,18 +25,18 @@ export const feature: Feature = ({ globalState, context }) => {
           let match = textBeforeCursor.match(regex)
 
           if (match) {
-            let packages: Record<ModuleName, vscode.CompletionItem[]> = {}
+            let packages = new Map<ModuleName, vscode.CompletionItem[]>()
             let moduleNameTheUserTyped = match[0].slice(0, -1)
 
             let aliasMap = getAliasesForCurrentFile(document)
             for (let [alias, moduleNames] of Object.entries(aliasMap)) {
               for (let moduleName of moduleNames) {
-                packages[alias] = packages[moduleName] || []
+                packages.set(alias, packages.get(moduleName) ?? [])
               }
             }
 
-            let matchingAliasedModules = aliasMap[moduleNameTheUserTyped]
-            let moduleName = matchingAliasedModules && matchingAliasedModules[0] || moduleNameTheUserTyped
+            let matchingAliasedModules = aliasMap.get(moduleNameTheUserTyped)
+            let moduleName = matchingAliasedModules?.[0] ?? moduleNameTheUserTyped
 
             let elmStuffFolder = path.join(elmJson.projectFolder, 'elm-stuff', '0.19.1')
             let elmiFilepaths = await vscode.workspace.fs.readDirectory(vscode.Uri.file(elmStuffFolder))
@@ -66,16 +66,16 @@ export const feature: Feature = ({ globalState, context }) => {
             }
 
             for (let [moduleDoc, dependency] of packageModuleDocs) {
-              packages[moduleDoc.name] = toCompletionItems(
+              packages.set(moduleDoc.name, toCompletionItems(
                 moduleDoc,
                 allModuleNames,
                 dependency.packageUserAndName
-              )
+              ))
             }
 
-            let value = packages[moduleName]
+            let value = packages.get(moduleName)
 
-            if (value) {
+            if (value !== undefined) {
               console.info(`autocomplete`, `${Date.now() - start}ms`)
               return value
             }
@@ -317,15 +317,15 @@ type ModuleName = string
 // This scans the file with a regex, so we can still provide
 // a good autocomplete experience, even for incomplete Elm files.
 // 
-const getAliasesForCurrentFile = (document: vscode.TextDocument): Record<string, ModuleName[]> => {
+const getAliasesForCurrentFile = (document: vscode.TextDocument): Map<string, ModuleName[]> => {
   let code = document.getText()
 
   // Start with the two aliases implicitly included
   // in every Elm file:
-  let alias: Record<string, string[]> = {
-    Cmd: ['Platform.Cmd'],
-    Sub: ['Platform.Sub'],
-  }
+  let alias = new Map<string, string[]>([
+    ['Cmd', ['Platform.Cmd']],
+    ['Sub', ['Platform.Sub']],
+  ])
 
   // Regular expression to match import statements
   let importRegex = /import\s([\w\.]+)(\sas\s(\w+))?/g
@@ -335,8 +335,12 @@ const getAliasesForCurrentFile = (document: vscode.TextDocument): Record<string,
     let moduleName = match[1]
     let aliasName = match[3]
     if (moduleName && aliasName) {
-      alias[aliasName] = alias[aliasName] || []
-      alias[aliasName]?.push(moduleName)
+      const previous = alias.get(aliasName)
+      if (previous === undefined) {
+        alias.set(aliasName, [moduleName])
+      } else {
+        previous.push(moduleName)
+      }
     }
   }
   return alias


### PR DESCRIPTION
If you have a function called `toString` (which I encounter a lot), this error appears in the VSCode developer tools:

```
ERR explicitMatches.concat is not a function: TypeError: explicitMatches.concat is not a function
	at Object.findImportedModuleNamesThatMightHaveExposedThisValue (/Users/simon/forks/vscode/dist/features/shared/elm-to-ast/elm-syntax.js:138:36)
	at findPackageLinksInExpression (/Users/simon/forks/vscode/dist/features/offline-package-docs.js:180:59)
	at findPackageLinksInExpression (/Users/simon/forks/vscode/dist/features/offline-package-docs.js:164:57)
	at async findPackageLinksInDeclaration (/Users/simon/forks/vscode/dist/features/offline-package-docs.js:80:47)
	at async Object.provideDocumentLinks (/Users/simon/forks/vscode/dist/features/offline-package-docs.js:262:39)
	at async Q.provideLinks (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:101:57504)
```

This is because we effectively do `someObject["toString"]` and expect to get an array back, but that’s a built-in function of all objects.

This PR switches to `someMap.get("toString")` instead, which is safer.

The first commit does it in the place that gets rid of the above error.

The second commit does it in some more places just in case.

The third commit is another tweak in code I touched anyway. There were some regexes that only supported A-Z, but other characters are allowed as well in module names and function names. For example, I’ve used the swedish ÅÄÖ in real code where it did not make sense to translate some very Swedish name/concept to English.

The fourth commit is a bonus. When typing `Json.` we now suggest the `Decode` and `Encode` modules. Previously, modules were only suggested if there was also functions or types in the namespace (there is nothing directly in `Json.`).