### PR TITLE
Fix jumping to definitions

### DIFF
--- a/src/features/jump-to-definition.ts
+++ b/src/features/jump-to-definition.ts
@@ -712,7 +712,11 @@ const provider = (globalState: GlobalState) => {
         case 'all':
           return null
         case 'as':
-          return null
+          if (argument.value.as.name.value === name) {
+            return argument.value.as.name.range
+          } else {
+            return null
+          }
         case 'char':
           return null
         case 'float':

--- a/src/features/jump-to-definition.ts
+++ b/src/features/jump-to-definition.ts
@@ -566,7 +566,7 @@ const provider = (globalState: GlobalState) => {
           let item = expression.value.lambda.expression
           let range = sharedLogic.fromElmRange(item.range)
           if (range.contains(position)) {
-            return findLocationOfItemsForExpression(item, args, localDeclarations, localPatterns)
+            return findLocationOfItemsForExpression(item, args, localDeclarations, localPatterns.concat(patterns))
           }
           return null
         case 'let':

--- a/src/features/jump-to-definition.ts
+++ b/src/features/jump-to-definition.ts
@@ -747,7 +747,9 @@ const provider = (globalState: GlobalState) => {
         case 'record':
           let matchingNode = argument.value.record.value.find(x => x.value === name)
           if (matchingNode) {
-            matchingNode.range
+            return matchingNode.range
+          } else {
+            return null
           }
         case 'string':
           return null


### PR DESCRIPTION
Fixes #11

Lambda parameters: All the code was already there, except one little piece where we add the patterns from the lambda parameters as things to jump to.

Any kind of destructuring in let bindings: Added them as local patterns, and also visit them similar to how lambda parameters are visited.

`as` patterns: Was only a problem in function declaration parameters. The code always returned `null`, now it checks if the `as` name matches.

Record destructuring: Also only a problem in function declaration parameters. It was due to a missing `return`, and then the code fell through to the next `case` and returned `null` there. Fallthrough can be caught by enabling [noFallthroughCasesInSwitch](https://www.typescriptlang.org/tsconfig#noFallthroughCasesInSwitch), and missing `return` can be found via ESLint. I might be able to help set that up some time if you want.