### PR TITLE
Update to elm-format 0.8.7 and support installation in Fish shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
   },
   "dependencies": {
     "elm": "0.19.1-5",
-    "elm-format": "0.8.5"
+    "elm-format": "0.8.7"
   },
   "devDependencies": {
     "@types/node": "18.11.18",

--- a/src/features/elm-format-on-save.ts
+++ b/src/features/elm-format-on-save.ts
@@ -7,7 +7,7 @@ export const feature: Feature = ({ context }) => {
   context.subscriptions.push(
     vscode.commands.registerCommand('elmLand.installElmFormat', () => {
       const terminal = vscode.window.createTerminal(`Install elm-format`)
-      terminal.sendText(`(cd ${os.homedir()} && npm install -g elm-format@0.8.5)`)
+      terminal.sendText(`(cd ${os.homedir()} && npm install -g elm-format@0.8.7)`)
       terminal.show()
     })
   )

--- a/src/features/elm-format-on-save.ts
+++ b/src/features/elm-format-on-save.ts
@@ -7,7 +7,7 @@ export const feature: Feature = ({ context }) => {
   context.subscriptions.push(
     vscode.commands.registerCommand('elmLand.installElmFormat', () => {
       const terminal = vscode.window.createTerminal(`Install elm-format`)
-      terminal.sendText(`(cd ${os.homedir()} && npm install -g elm-format@0.8.7)`)
+      terminal.sendText(`npm install -g elm-format@0.8.7`)
       terminal.show()
     })
   )
@@ -44,23 +44,23 @@ function runElmFormat(document: vscode.TextDocument): Promise<string> {
         env: sharedLogic.npxEnv()
       },
       async (err, stdout, stderr) => {
-      if (err) {
-        const ELM_FORMAT_BINARY_NOT_FOUND = 127
-        if (err.code === ELM_FORMAT_BINARY_NOT_FOUND || err.message.includes(`'elm-format' is not recognized`)) {
-          let response = await vscode.window.showWarningMessage(
-            'The "Format on save" feature requires "elm-format"',
-            { modal: false },
-            'Install'
-          )
-          if (response === 'Install') {
-            vscode.commands.executeCommand('elmLand.installElmFormat')
+        if (err) {
+          const ELM_FORMAT_BINARY_NOT_FOUND = 127
+          if (err.code === ELM_FORMAT_BINARY_NOT_FOUND || err.message.includes(`'elm-format' is not recognized`)) {
+            let response = await vscode.window.showWarningMessage(
+              'The "Format on save" feature requires "elm-format"',
+              { modal: false },
+              'Install'
+            )
+            if (response === 'Install') {
+              vscode.commands.executeCommand('elmLand.installElmFormat')
+            }
           }
+          reject(err)
+        } else {
+          resolve(stdout)
         }
-        reject(err)
-      } else {
-        resolve(stdout)
-      }
-    })
+      })
     process_.stdin?.write(original)
     process_.stdin?.end()
     return process_

--- a/src/features/error-highlighting.ts
+++ b/src/features/error-highlighting.ts
@@ -14,7 +14,7 @@ export const feature: Feature = ({ globalState, context }) => {
   context.subscriptions.push(
     vscode.commands.registerCommand('elmLand.installElm', () => {
       const terminal = vscode.window.createTerminal(`Install elm`)
-      terminal.sendText(`(cd ${os.homedir()} && npm install -g elm@0.19.1)`)
+      terminal.sendText(`npm install -g elm@0.19.1`)
       terminal.show()
     })
   )

--- a/src/features/html-to-elm/src/Main.elm
+++ b/src/features/html-to-elm/src/Main.elm
@@ -52,7 +52,7 @@ fromHtmlToElm html =
 
         Err problem ->
             Nothing
-            
+
 
 toElmString : List Html.Parser.Node -> String
 toElmString elements =
@@ -79,8 +79,7 @@ toElmString elements =
                         |> Elm.Pretty.prettyExpression
     in
     Pretty.pretty 80 doc
-    
-    
+
 
 toNodeExpression : Html.Parser.Node -> Maybe Elm.Syntax.Expression.Expression
 toNodeExpression node =
@@ -109,7 +108,8 @@ toNodeExpression node =
 
                                 Nothing ->
                                     if tagName == "pathmango" then
-                                        [ Elm.Syntax.Expression.FunctionOrValue [] ("path") ]
+                                        [ Elm.Syntax.Expression.FunctionOrValue [] "path" ]
+
                                     else if tagName == "main" || tagName == "text" then
                                         [ Elm.Syntax.Expression.FunctionOrValue [] (tagName ++ "_") ]
 


### PR DESCRIPTION
The latest version is much faster, and has zero deprecated sub dependencies.

Bonus fixes:

- Installing elm-format now works in non-bash-like shells, like the [Fish shell](https://fishshell.com/) (which I use). This was fixed by removing `(cd home && )` (in Fish, parentheses means something else and is not valid there). I have never heard of it mattering which folder you’re in when installing something _globally_ with npm.
- Did the same fix for installing Elm.
- Indented a callback 🙃 