### PR TITLE
Allow user to configure an alternative Elm compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
         "command": "elmLand.htmlToElm",
         "enablement": "false"
       },
-      { 
+      {
         "category": "Elm Land",
         "title": "Install Elm",
         "command": "elmLand.installElm",
         "enablement": "false"
       },
-      { 
+      {
         "category": "Elm Land",
         "title": "Install elm-format",
         "command": "elmLand.installElmFormat",
@@ -112,6 +112,12 @@
             "description": "Enable the 'HTML to Elm' feature",
             "type": "boolean",
             "default": true
+          },
+          "elmLand.compilerFilepath": {
+            "order": 7,
+            "description": "The path to your Elm compiler",
+            "type": "string",
+            "default": "elm"
           }
         }
       }

--- a/src/features/error-highlighting.ts
+++ b/src/features/error-highlighting.ts
@@ -128,10 +128,12 @@ const Elm = {
     const promise: Promise<ParsedError | undefined> =
       new Promise((resolve, reject) => {
         const isWindows = process.platform === 'win32'
+        const compiler = vscode.workspace.getConfiguration('elmLand').compilerFilepath;
+        console.log('compilerFilepath:', compiler);
         // This uses `spawn` so that we can support folders with spaces in them
         // without having to think about escaping.
         const child = child_process.spawn(
-          'elm',
+          compiler,
           [
             'make',
             // `shell: true` is needed on Windows to execute shell scripts (non .exe files).

--- a/src/features/error-highlighting.ts
+++ b/src/features/error-highlighting.ts
@@ -129,7 +129,7 @@ const Elm = {
       new Promise((resolve, reject) => {
         const isWindows = process.platform === 'win32'
         const compiler = vscode.workspace.getConfiguration('elmLand').compilerFilepath;
-        console.log('compilerFilepath:', compiler);
+
         // This uses `spawn` so that we can support folders with spaces in them
         // without having to think about escaping.
         const child = child_process.spawn(


### PR DESCRIPTION
This would allow Lamdera users to configure the plugin to always use the Lamdera compiler (which is backwards compatible with any Elm project).