### PR TITLE
Update to the latest elm npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "referencesProvider": "true"
   },
   "dependencies": {
-    "elm": "0.19.1-5",
+    "elm": "0.19.1-6",
     "elm-format": "0.8.7"
   },
   "devDependencies": {

--- a/src/features/error-highlighting.ts
+++ b/src/features/error-highlighting.ts
@@ -14,7 +14,7 @@ export const feature: Feature = ({ globalState, context }) => {
   context.subscriptions.push(
     vscode.commands.registerCommand('elmLand.installElm', () => {
       const terminal = vscode.window.createTerminal(`Install elm`)
-      terminal.sendText(`npm install -g elm@0.19.1`)
+      terminal.sendText(`npm install -g elm@0.19.1-6`)
       terminal.show()
     })
   )


### PR DESCRIPTION
The popup asking if you want to install Elm is currently installing the elm npm package version [0.19.1](https://www.npmjs.com/package/elm/v/0.19.1) which is ancient and marked as deprecated on npm.

This PR updates to installing the just-released version 0.19.1-6, which is faster to install due to having 0 dependencies, and doesn’t print scary deprecation warnings.

I chose to hard code `0.19.1-6` since the elm-format version is hard coded in its similar popup. Another option is to say `elm@latest-0.19.1`. But then we’ll have to wait for a bit, because Evan wanted to see that people don’t report that the new version is working badly before updating that tag.