### PR TITLE
Update to latest version of elm-syntax

### DIFF
--- a/src/features/html-to-elm/elm.json
+++ b/src/features/html-to-elm/elm.json
@@ -10,7 +10,7 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "jims/html-parser": "1.0.0",
-            "stil4m/elm-syntax": "7.3.4",
+            "stil4m/elm-syntax": "7.3.7",
             "the-sett/elm-pretty-printer": "3.0.0",
             "the-sett/elm-syntax-dsl": "6.0.2"
         },

--- a/src/features/html-to-elm/elm.json
+++ b/src/features/html-to-elm/elm.json
@@ -10,7 +10,7 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "jims/html-parser": "1.0.0",
-            "stil4m/elm-syntax": "7.3.7",
+            "stil4m/elm-syntax": "7.3.8",
             "the-sett/elm-pretty-printer": "3.0.0",
             "the-sett/elm-syntax-dsl": "6.0.2"
         },

--- a/src/features/html-to-elm/elm.json
+++ b/src/features/html-to-elm/elm.json
@@ -10,7 +10,7 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "jims/html-parser": "1.0.0",
-            "stil4m/elm-syntax": "7.3.3",
+            "stil4m/elm-syntax": "7.3.4",
             "the-sett/elm-pretty-printer": "3.0.0",
             "the-sett/elm-syntax-dsl": "6.0.2"
         },

--- a/src/features/html-to-elm/elm.json
+++ b/src/features/html-to-elm/elm.json
@@ -10,7 +10,7 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "jims/html-parser": "1.0.0",
-            "stil4m/elm-syntax": "7.2.9",
+            "stil4m/elm-syntax": "7.3.3",
             "the-sett/elm-pretty-printer": "3.0.0",
             "the-sett/elm-syntax-dsl": "6.0.2"
         },

--- a/src/features/shared/elm-to-ast/elm-syntax.ts
+++ b/src/features/shared/elm-to-ast/elm-syntax.ts
@@ -1,7 +1,7 @@
 /**
  * The JSON AST encoded by the `stil4m/elm-syntax` package:
  * 
- * https://package.elm-lang.org/packages/stil4m/elm-syntax/7.3.7
+ * https://package.elm-lang.org/packages/stil4m/elm-syntax/7.3.8
  * 
  */
 

--- a/src/features/shared/elm-to-ast/elm-syntax.ts
+++ b/src/features/shared/elm-to-ast/elm-syntax.ts
@@ -1,7 +1,7 @@
 /**
  * The JSON AST encoded by the `stil4m/elm-syntax` package:
  * 
- * https://package.elm-lang.org/packages/stil4m/elm-syntax/7.3.3
+ * https://package.elm-lang.org/packages/stil4m/elm-syntax/7.3.4
  * 
  */
 

--- a/src/features/shared/elm-to-ast/elm-syntax.ts
+++ b/src/features/shared/elm-to-ast/elm-syntax.ts
@@ -1,7 +1,7 @@
 /**
  * The JSON AST encoded by the `stil4m/elm-syntax` package:
  * 
- * https://package.elm-lang.org/packages/stil4m/elm-syntax/7.3.4
+ * https://package.elm-lang.org/packages/stil4m/elm-syntax/7.3.7
  * 
  */
 

--- a/src/features/shared/elm-to-ast/elm-syntax.ts
+++ b/src/features/shared/elm-to-ast/elm-syntax.ts
@@ -1,7 +1,7 @@
 /**
  * The JSON AST encoded by the `stil4m/elm-syntax` package:
  * 
- * https://package.elm-lang.org/packages/stil4m/elm-syntax/7.2.9
+ * https://package.elm-lang.org/packages/stil4m/elm-syntax/7.3.3
  * 
  */
 

--- a/src/features/shared/elm-to-ast/elm.json
+++ b/src/features/shared/elm-to-ast/elm.json
@@ -10,7 +10,7 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
-            "stil4m/elm-syntax": "7.2.9"
+            "stil4m/elm-syntax": "7.3.3"
         },
         "indirect": {
             "elm/parser": "1.1.0",

--- a/src/features/shared/elm-to-ast/elm.json
+++ b/src/features/shared/elm-to-ast/elm.json
@@ -10,7 +10,7 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
-            "stil4m/elm-syntax": "7.3.4"
+            "stil4m/elm-syntax": "7.3.7"
         },
         "indirect": {
             "elm/parser": "1.1.0",

--- a/src/features/shared/elm-to-ast/elm.json
+++ b/src/features/shared/elm-to-ast/elm.json
@@ -10,7 +10,7 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
-            "stil4m/elm-syntax": "7.3.7"
+            "stil4m/elm-syntax": "7.3.8"
         },
         "indirect": {
             "elm/parser": "1.1.0",

--- a/src/features/shared/elm-to-ast/elm.json
+++ b/src/features/shared/elm-to-ast/elm.json
@@ -10,7 +10,7 @@
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
-            "stil4m/elm-syntax": "7.3.3"
+            "stil4m/elm-syntax": "7.3.4"
         },
         "indirect": {
             "elm/parser": "1.1.0",


### PR DESCRIPTION
https://github.com/stil4m/elm-syntax/blob/fcac5e99c1fab7cffea48e728d7034bad526c1e1/CHANGELOG.md

The changelog mentions massive performance gains in each release. The work seems to have stabilized now, so we should be able to update and gain better performance.