### PR TITLE
Increase number of elm.json findable

### DIFF
--- a/src/features/shared/autodetect-elm-json.ts
+++ b/src/features/shared/autodetect-elm-json.ts
@@ -48,7 +48,7 @@ export const run = async (globalState: GlobalState) => {
     entrypointFilepaths: config.get('entrypointFilepaths') || []
   }
 
-  let elmJsonFileUris = await vscode.workspace.findFiles('**/elm.json', '**/node_modules/**', 10)
+  let elmJsonFileUris = await vscode.workspace.findFiles('**/elm.json', '**/node_modules/**', 100)
   let possibleElmJsonFiles = await Promise.all(toElmJsonFiles({ elmJsonFileUris, settings }))
   globalState.elmJsonFiles = possibleElmJsonFiles.filter(sharedLogic.isDefined)
   globalState.cachedDocs = new Map()


### PR DESCRIPTION
We use `elmland` in a big monorepo that includes a couple of real `elm.json` files as well as some random `elm.json` files copied into `dist` folders as part of the build process. This was breaking the limit of `10` set here, so some real `elm.json` files weren't getting picked up.

100 `elm.json`s should be enough for anyone, right?